### PR TITLE
Don't treat plain str as rich markup

### DIFF
--- a/src/diagnostic/_parsers.py
+++ b/src/diagnostic/_parsers.py
@@ -73,7 +73,6 @@ def find_codes_in_sources(src_path: Path) -> codeLocationMapping:
         with open(file) as f:
             tree = ast.parse(f.read())
 
-        print(ast.dump(tree))
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 for attr in node.body:
@@ -95,7 +94,6 @@ def find_codes_in_sources(src_path: Path) -> codeLocationMapping:
                             continue
                         codes[ref].append((file, node.lineno))
             elif isinstance(node, ast.Call):
-                print(ast.dump(node))
                 for kw in node.keywords:
                     if kw.arg == "code" and isinstance(kw.value, ast.Str):
                         ref = kw.value.s

--- a/tests/data/error-color.yml
+++ b/tests/data/error-color.yml
@@ -23,8 +23,8 @@
   ascii: |
     \e[1;31merror\e[0m: \e[1mtest-diagnostic\e[0m
 
-    You touched a bit and it \e[33mchanged\e[0m.
-    :\e[1m(\e[0m
+    You touched a bit and it [yellow]changed[/].
+    :(
 
     It has broken some logic and that is
     very bad.
@@ -39,8 +39,8 @@
   unicode: |
     \e[1;31merror\e[0m: \e[1mtest-diagnostic\e[0m
 
-    \e[31m×\e[0m You touched a bit and it \e[33mchanged\e[0m.
-    \e[31m│\e[0m :\e[1m(\e[0m
+    \e[31m×\e[0m You touched a bit and it [yellow]changed[/].
+    \e[31m│\e[0m :(
     \e[31m├─>\e[0m It has broken some logic and that is
     \e[31m│  \e[0m very bad.
     \e[31m╰─>\e[0m It is bad.
@@ -65,7 +65,7 @@
   ascii: |
     \e[1;31merror\e[0m: \e[1mtest-diagnostic\e[0m
 
-    You touched a bit and it [yellow]changed[/].
+    You touched a bit and it \e[33mchanged\e[0m.
     :(
 
     It has broken some logic and that is
@@ -81,7 +81,7 @@
   unicode: |
     \e[1;31merror\e[0m: \e[1mtest-diagnostic\e[0m
 
-    \e[31m×\e[0m You touched a bit and it [yellow]changed[/].
+    \e[31m×\e[0m You touched a bit and it \e[33mchanged\e[0m.
     \e[31m│\e[0m :(
     \e[31m├─>\e[0m It has broken some logic and that is
     \e[31m│  \e[0m very bad.

--- a/tests/data/error.yml
+++ b/tests/data/error.yml
@@ -11,7 +11,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     Caused by:
@@ -28,7 +28,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     It has broken some logic and that is
@@ -44,7 +44,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
     │ :(
     ├─> It has broken some logic and that is
     │   very bad.
@@ -68,7 +68,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     note: This was a user error
@@ -78,7 +78,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     note: This was a user error
@@ -88,7 +88,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
       :(
 
     note: This was a user error
@@ -109,7 +109,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     Caused by:
@@ -122,7 +122,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     It has broken some logic and that is
@@ -134,7 +134,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
     │ :(
     ├─> It has broken some logic and that is
     │   very bad.
@@ -156,7 +156,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     Caused by:
@@ -169,7 +169,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     It has broken some logic and that is
@@ -181,7 +181,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
     │ :(
     ├─> It has broken some logic and that is
     │   very bad.
@@ -201,7 +201,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     note: This was a user error
@@ -209,7 +209,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     note: This was a user error
@@ -217,7 +217,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
       :(
 
     note: This was a user error
@@ -234,7 +234,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     hint: Avoid the user error in the future
@@ -242,7 +242,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     hint: Avoid the user error in the future
@@ -250,7 +250,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
       :(
 
     hint: Avoid the user error in the future
@@ -269,7 +269,7 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     Caused by:
@@ -279,7 +279,7 @@
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
 
     It has broken some logic and that is
@@ -288,7 +288,7 @@
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
     │ :(
     ├─> It has broken some logic and that is
     │   very bad.
@@ -305,15 +305,15 @@
   str: |-
     test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
   ascii: |
     error: test-diagnostic
 
-    You touched a bit and it changed.
+    You touched a bit and it [yellow]changed[/].
     :(
   unicode: |
     error: test-diagnostic
 
-    × You touched a bit and it changed.
+    × You touched a bit and it [yellow]changed[/].
       :(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -19,7 +19,7 @@ def load_data_from_yaml(filename: str) -> list[dict[str, Any]]:
     def my_rich_text_constructor(
         loader: yaml.FullLoader, node: yaml.ScalarNode
     ) -> Text:
-        return Text(cast(str, loader.construct_scalar(node)))
+        return Text.from_markup(cast(str, loader.construct_scalar(node)))
 
     complete_filename = os.path.join(
         os.path.dirname(__file__),


### PR DESCRIPTION


This makes it easier to use f-strings to render errors.

